### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,18 +4,318 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "abstract-logging": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-1.0.0.tgz",
-      "integrity": "sha1-i33q/TEFWbwo93ck3RuzAXcnjBs="
-    },
-    "ammo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.3.tgz",
-      "integrity": "sha512-vo76VJ44MkUBZL/BzpGXaKzMfroF4ZR6+haRuw9p+eSWfoNaH2AxVc8xmiEPC08jhzJSeM6w7/iMUGet8b4oBQ==",
+    "@hapi/accept": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
+      "integrity": "sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==",
       "requires": {
-        "hoek": "6.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
+    },
+    "@hapi/ammo": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/b64": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/boom": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
+      "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/bounce": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/bourne": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+      "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+    },
+    "@hapi/call": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/catbox": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/podium": "4.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "@hapi/catbox-memory": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.0.tgz",
+      "integrity": "sha512-ByuxVJPHNaXwLzbBv4GdTr6ccpe1nG+AfYt+8ftDWEJY7EWBWzD+Klhy5oPTDGzU26pNUh1e7fcYI1ILZRxAXQ==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/content": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+      "requires": {
+        "@hapi/boom": "9.x.x"
+      }
+    },
+    "@hapi/cryptiles": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+      "requires": {
+        "@hapi/boom": "9.x.x"
+      }
+    },
+    "@hapi/file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
+    },
+    "@hapi/hapi": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.0.0.tgz",
+      "integrity": "sha512-Wh0tIDFsl7nemU2JQYW4zZVr9XkpuZ1eM3yaX8tzaYdaYXon8QeB5NzrTNQY3R1/+fO7amQUrOoLLNPRwIZfgw==",
+      "requires": {
+        "@hapi/accept": "^5.0.1",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/call": "8.x.x",
+        "@hapi/catbox": "^11.1.1",
+        "@hapi/catbox-memory": "5.x.x",
+        "@hapi/heavy": "^7.0.1",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/mimos": "5.x.x",
+        "@hapi/podium": "^4.1.1",
+        "@hapi/shot": "^5.0.1",
+        "@hapi/somever": "3.x.x",
+        "@hapi/statehood": "^7.0.3",
+        "@hapi/subtext": "^7.0.3",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/topo": "5.x.x",
+        "@hapi/validate": "^1.1.0"
+      }
+    },
+    "@hapi/heavy": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "@hapi/hoek": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
+    },
+    "@hapi/inert": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-6.0.2.tgz",
+      "integrity": "sha512-cq0a8jstkLW1+oJaw4jp52PZBEkVbX9d0YDy5aOs3rOKYSjpzs2nQBahnCHEMchOrOSUffLpE+IDoivYHcx8uA==",
+      "requires": {
+        "@hapi/ammo": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x",
+        "lru-cache": "5.x.x"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
+    },
+    "@hapi/iron": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+      "requires": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/mimos": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
+      "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
+      "requires": {
+        "@hapi/hoek": "9.x.x",
+        "mime-db": "1.x.x"
+      }
+    },
+    "@hapi/nigel": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/vise": "^4.0.0"
+      }
+    },
+    "@hapi/pez": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
+      "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+      "requires": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/nigel": "4.x.x"
+      }
+    },
+    "@hapi/podium": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.1.tgz",
+      "integrity": "sha512-jh7a6+5Z4FUWzx8fgmxjaAa1DTBu+Qfg+NbVdo0f++rE5DgsVidUYrLDp3db65+QjDLleA2MfKQXkpT8ylBDXA==",
+      "requires": {
+        "@hapi/hoek": "9.x.x",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "@hapi/shot": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.3.tgz",
+      "integrity": "sha512-qbccs8KL4YSL9x0J/17Z6Udmtrrn32ieGbrCW8iivl2ha8YzlDy9Wvv1pFKh3mzbTsomWHGLF3UsKcQFk/BqPg==",
+      "requires": {
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "@hapi/somever": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
+      "integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
+      "requires": {
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/statehood": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
+      "integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/iron": "6.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "@hapi/subtext": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
+      "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/file": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/pez": "^5.0.1",
+        "@hapi/wreck": "17.x.x"
+      }
+    },
+    "@hapi/teamwork": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
+      "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg=="
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@hapi/validate": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.2.tgz",
+      "integrity": "sha512-ojg3iE/haKh8aCZFObkOzuJ1vQ8NP+EiuibliJKe01IMstBPXQc4Xl08+8zqAL+iZSZKp1TaWdwaNSzq8HIMKA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "@hapi/vise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/wreck": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.0.0.tgz",
+      "integrity": "sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "abstract-logging": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.0.tgz",
+      "integrity": "sha512-/oA9z7JszpIioo6J6dB79LVUgJ3eD3cxkAmdCkvWWS+Y9tPtALs1rLqOekLUXUbYqM2fB9TTK0ibAyZJJOP/CA=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -26,32 +326,32 @@
       }
     },
     "args": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/args/-/args-5.0.0.tgz",
-      "integrity": "sha512-eCZo33yLdQ3DiG/Ko5n11uPonyYofYd9F2cqWID8TKGZwK/Z2ZcUj/oZ1HNMeNL2lgraPnv3JBZumfbUMqmZtg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
       "requires": {
         "camelcase": "5.0.0",
-        "chalk": "2.4.1",
+        "chalk": "2.4.2",
         "leven": "2.1.0",
-        "mri": "1.1.1"
+        "mri": "1.1.4"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
-    "boom": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
-      "requires": {
-        "hoek": "6.x.x"
-      }
-    },
-    "bounce": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.3.tgz",
-      "integrity": "sha512-3G7B8CyBnip5EahCZJjnvQ1HLyArC6P5e+xcolo13BVI9ogFaDOsNMAE7FIWliHtIkYI8/nTRCvCY9tZa3Mu4g==",
-      "requires": {
-        "boom": "7.x.x",
-        "hoek": "6.x.x"
-      }
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "camelcase": {
       "version": "5.0.0",
@@ -59,13 +359,49 @@
       "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "color-convert": {
@@ -87,9 +423,9 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
@@ -99,307 +435,30 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
-    "fast-json-parse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
-      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw=="
-    },
     "fast-redact": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-1.4.2.tgz",
-      "integrity": "sha512-ttC8IgelNvYqb9RBC+rirgUCVPtPVonfdeRdsHBcBx3kzQat1DafbUKAEhLo5GnvuBqda+Xe1BvblecPpQkZ2Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
+      "integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
     },
     "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "flatstr": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.9.tgz",
-      "integrity": "sha512-qFlJnOBWDfIaunF54/lBqNKmXOI0HqNhu+mHkLmbaBXlS71PUd9OjFOdyevHt/aHoHB1+eW7eKHgRKOG5aHSpw=="
-    },
-    "hapi": {
-      "version": "17.8.1",
-      "resolved": "https://registry.npmjs.org/hapi/-/hapi-17.8.1.tgz",
-      "integrity": "sha512-0zfkl8YtJPfkOG+1KwFnZOk7/mmO2LrExJLWIJwzmwsyxLcQXNrnfwgk205xxxg9tnOO6OdCTQLkPG8Wn+McXw==",
-      "requires": {
-        "accept": "3.x.x",
-        "ammo": "3.x.x",
-        "boom": "7.x.x",
-        "bounce": "1.x.x",
-        "call": "5.x.x",
-        "catbox": "10.x.x",
-        "catbox-memory": "3.x.x",
-        "heavy": "6.x.x",
-        "hoek": "6.x.x",
-        "joi": "14.x.x",
-        "mimos": "4.x.x",
-        "podium": "3.x.x",
-        "shot": "4.x.x",
-        "somever": "2.x.x",
-        "statehood": "6.x.x",
-        "subtext": "6.x.x",
-        "teamwork": "3.x.x",
-        "topo": "3.x.x"
-      },
-      "dependencies": {
-        "accept": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/accept/-/accept-3.1.3.tgz",
-          "integrity": "sha512-OgOEAidVEOKPup+Gv2+2wdH2AgVKI9LxsJ4hicdJ6cY0faUuZdZoi56kkXWlHp9qicN1nWQLmW5ZRGk+SBS5xg==",
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "ammo": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.3.tgz",
-          "integrity": "sha512-vo76VJ44MkUBZL/BzpGXaKzMfroF4ZR6+haRuw9p+eSWfoNaH2AxVc8xmiEPC08jhzJSeM6w7/iMUGet8b4oBQ==",
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "b64": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/b64/-/b64-4.1.2.tgz",
-          "integrity": "sha512-+GUspBxlH3CJaxMUGUE1EBoWM6RKgWiYwUDal0qdf8m3ArnXNN1KzKVo5HOnE/FSq4HHyWf3TlHLsZI8PKQgrQ==",
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "big-time": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/big-time/-/big-time-2.0.1.tgz",
-          "integrity": "sha512-qtwYYoocwpiAxTXC5sIpB6nH5j6ckt+n/jhD7J5OEiFHnUZEFn0Xk8STUaE5s10LdazN/87bTDMe+fSihaW7Kg=="
-        },
-        "boom": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.2.tgz",
-          "integrity": "sha512-IFUbOa8PS7xqmhIjpeStwT3d09hGkNYQ6aj2iELSTxcVs2u0aKn1NzhkdUQSzsRg1FVkj3uit3I6mXQCBixw+A==",
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "bounce": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.2.tgz",
-          "integrity": "sha512-1LPcXg3fkGVhjdA/P3DcR5cDktKEYtDpruJv9Nhmy36RoYaoxZfC82Zr2JmS3vysDJKqMtP0qJw3/P6iisTASg==",
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "call": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/call/-/call-5.0.3.tgz",
-          "integrity": "sha512-eX16KHiAYXugbFu6VifstSdwH6aMuWWb4s0qvpq1nR1b+Sf+u68jjttg8ixDBEldPqBi30bDU35OJQWKeTLKxg==",
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "catbox": {
-          "version": "10.0.5",
-          "resolved": "https://registry.npmjs.org/catbox/-/catbox-10.0.5.tgz",
-          "integrity": "sha512-5SpI/tEP3SiLE1qkkV+/hdVW48sHVBEbzPX4jBiwl6hsZh/gkl4bqfGLkvh7mjpMK5evJ0Rm/6NRlhF/Jsy9ow==",
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "catbox-memory": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-3.1.4.tgz",
-          "integrity": "sha512-1tDnll066au0HXBSDHS/YQ34MQ2omBsmnA9g/jseyq/M3m7UPrajVtPDZK/rXgikSC1dfjo9Pa+kQ1qcyG2d3g==",
-          "requires": {
-            "big-time": "2.x.x",
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "content": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/content/-/content-4.0.6.tgz",
-          "integrity": "sha512-lR9ND3dXiMdmsE84K6l02rMdgiBVmtYWu1Vr/gfSGHcIcznBj2QxmSdUgDuNFOA+G9yrb1IIWkZ7aKtB6hDGyA==",
-          "requires": {
-            "boom": "7.x.x"
-          }
-        },
-        "cryptiles": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
-          "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
-          "requires": {
-            "boom": "7.x.x"
-          }
-        },
-        "heavy": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/heavy/-/heavy-6.1.2.tgz",
-          "integrity": "sha512-cJp884bqhiebNcEHydW0g6V1MUGYOXRPw9c7MFiHQnuGxtbWuSZpsbojwb2kxb3AA1/Rfs8CNiV9MMOF8pFRDg==",
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "hoek": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.1.tgz",
-          "integrity": "sha512-3PvUwBerLNVJiIVQdpkWF9F/M0ekgb2NPJWOhsE28RXSQPsY42YSnaJ8d1kZjcAz58TZ/Fk9Tw64xJsENFlJNw=="
-        },
-        "iron": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.6.tgz",
-          "integrity": "sha512-zYUMOSkEXGBdwlV/AXF9zJC0aLuTJUKHkGeYS5I2g225M5i6SrxQyGJGhPgOR8BK1omL6N5i6TcwfsXbP8/Exw==",
-          "requires": {
-            "b64": "4.x.x",
-            "boom": "7.x.x",
-            "cryptiles": "4.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "joi": {
-          "version": "14.0.4",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-14.0.4.tgz",
-          "integrity": "sha512-KUXRcinDUMMbtlOk7YLGHQvG73dLyf8bmgE+6sBTkdJbZpeGVGAlPXEHLiQBV7KinD/VLD5OA0EUgoTTfbRAJQ==",
-          "requires": {
-            "hoek": "6.x.x",
-            "isemail": "3.x.x",
-            "topo": "3.x.x"
-          }
-        },
-        "mime-db": {
-          "version": "1.37.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-          "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
-        },
-        "mimos": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/mimos/-/mimos-4.0.2.tgz",
-          "integrity": "sha512-5XBsDqBqzSN88XPPH/TFpOalWOjHJM5Z2d3AMx/30iq+qXvYKd/8MPhqBwZDOLtoaIWInR3nLzMQcxfGK9djXA==",
-          "requires": {
-            "hoek": "6.x.x",
-            "mime-db": "1.x.x"
-          }
-        },
-        "nigel": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.4.tgz",
-          "integrity": "sha512-3SZCCS/duVDGxFpTROHEieC+itDo4UqL9JNUyQJv3rljudQbK6aqus5B4470OxhESPJLN93Qqxg16rH7DUjbfQ==",
-          "requires": {
-            "hoek": "6.x.x",
-            "vise": "3.x.x"
-          }
-        },
-        "pez": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/pez/-/pez-4.0.5.tgz",
-          "integrity": "sha512-HvL8uiFIlkXbx/qw4B8jKDCWzo7Pnnd65Uvanf9OOCtb20MRcb9gtTVBf9NCnhETif1/nzbDHIjAWC/sUp7LIQ==",
-          "requires": {
-            "b64": "4.x.x",
-            "boom": "7.x.x",
-            "content": "4.x.x",
-            "hoek": "6.x.x",
-            "nigel": "3.x.x"
-          }
-        },
-        "podium": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/podium/-/podium-3.1.5.tgz",
-          "integrity": "sha512-+fAPmAj3d5fWKx5oSjQKeBIcl46/qZnGLhzyi/dJ/HzNiOpuxyX/Y4091LiVxZQ4ALdf/LCS7siV6ai5nNLlOg==",
-          "requires": {
-            "hoek": "6.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "shot": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/shot/-/shot-4.0.7.tgz",
-          "integrity": "sha512-RKaKAGKxJ11EjJl0cf2fYVSsd4KB5Cncb9J0v7w+0iIaXpxNqFWTYNDNhBX7f0XSyDrjOH9a4OWZ9Gp/ZML+ew==",
-          "requires": {
-            "hoek": "6.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "somever": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/somever/-/somever-2.0.0.tgz",
-          "integrity": "sha512-9JaIPP+HxwYGqCDqqK3tRaTqdtQHoK6Qy3IrXhIt2q5x8fs8RcfU7BMWlFTCOgFazK8p88zIv1tHQXvAwtXMyw==",
-          "requires": {
-            "bounce": "1.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "statehood": {
-          "version": "6.0.8",
-          "resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.8.tgz",
-          "integrity": "sha512-/uk2Iq5VXCAGmYnRTjez6gDfU8fROm1Um5WH2C9aNCdG7DAqD94dqZgeuqXrvVFnfDqxAtorUBLUtD9El/uJ6w==",
-          "requires": {
-            "boom": "7.x.x",
-            "bounce": "1.x.x",
-            "cryptiles": "4.x.x",
-            "hoek": "6.x.x",
-            "iron": "5.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "subtext": {
-          "version": "6.0.11",
-          "resolved": "https://registry.npmjs.org/subtext/-/subtext-6.0.11.tgz",
-          "integrity": "sha512-jap1ev33dbVTBPxpIyJ5OvD9/J4oWlx1qHQ8bBnKpiwItxXt3+7tvmNZqZeTEQVTjvkReHY1ZnP/7iltNdGnOA==",
-          "requires": {
-            "boom": "7.x.x",
-            "content": "4.x.x",
-            "hoek": "6.x.x",
-            "pez": "4.x.x",
-            "wreck": "14.x.x"
-          }
-        },
-        "teamwork": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/teamwork/-/teamwork-3.0.2.tgz",
-          "integrity": "sha512-tpG01+9Qws/oGhMBiZN3BnB32gn5QeKY84AmLxxaCJw4mNeRzhEZ6jEj/vBhKerHD7Hgq9/vOZ58pyryYSn9gA=="
-        },
-        "topo": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "vise": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/vise/-/vise-3.0.1.tgz",
-          "integrity": "sha512-7BJNjsv2o83+E6AHAFSnjQF324UTgypsR/Sw/iFmLvr7RgJrEXF1xNBvb5LJfi+1FvWQXjJK4X41WMuHMeunPQ==",
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "wreck": {
-          "version": "14.1.3",
-          "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.1.3.tgz",
-          "integrity": "sha512-hb/BUtjX3ObbwO3slCOLCenQ4EP8e+n8j6FmTne3VhEFp5XV1faSJojiyxVSvw34vgdeTG5baLTl4NmjwokLlw==",
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        }
-      }
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "hapi-pino": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-5.2.0.tgz",
-      "integrity": "sha512-OJnEPcnaZL41s9FU8NO0WBdGgx+YMNsF/OpjfosXVbSjOZu9JJHXG/I9UdAlFrJaTo+EF3605j9XXWhy8Xbx6g==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-8.2.0.tgz",
+      "integrity": "sha512-L7XtPVYm/XCr5j8hVSg5D85yW14FbBwSRerKyfUwXbv8+uUx3UrX/BC6RSPJu4B/UYPjSccxaSwx7ss/1s0Z3Q==",
       "requires": {
-        "abstract-logging": "^1.0.0",
-        "hoek": "^6.1.2",
-        "pino": "^5.10.1",
-        "pino-pretty": "^2.5.0"
+        "@hapi/hoek": "^9.0.0",
+        "abstract-logging": "^2.0.0",
+        "pino": "^6.0.0",
+        "pino-pretty": "^4.0.0"
       }
     },
     "has-flag": {
@@ -407,70 +466,35 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
-    "hoek": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-      "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
-    },
-    "inert": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/inert/-/inert-5.1.2.tgz",
-      "integrity": "sha512-5jSCKrQ7ENfdECnzLatCejXSkJwVzKFXZW30fI6TNHFbDuigT8IilRfydI2H5j9ZTnH7vXKO4WUg2qph9bItow==",
-      "requires": {
-        "ammo": "3.x.x",
-        "boom": "7.x.x",
-        "bounce": "1.x.x",
-        "hoek": "6.x.x",
-        "joi": "14.x.x",
-        "lru-cache": "4.1.x"
-      }
-    },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "isemail": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "requires": {
-        "punycode": "2.x.x"
-      }
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
-    "joi": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
-      "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
-      "requires": {
-        "hoek": "6.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
-      }
+    "joycon": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
+      "integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ=="
     },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
       "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
     },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mri": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.1.tgz",
-      "integrity": "sha1-haom09ru7t+A3FmEr5XMXKXK2fE="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
     },
     "once": {
       "version": "1.4.0",
@@ -481,43 +505,40 @@
       }
     },
     "pino": {
-      "version": "5.10.5",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-5.10.5.tgz",
-      "integrity": "sha512-WtrALBJSaFgAAwEOCIime51KesWuPgXHTCFWtJRjhEcOg72OEsNlmYLaE4MJONgPvwV8xWuJx1JtXkqb9VD4ig==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.5.1.tgz",
+      "integrity": "sha512-76+RUhQkqjUD4AtQcSfEzh6vlsjXmoWZK5gg+2d70aCLXZTbo4/5js4I9rN1Xk6z1h2/7pnOFX10G4c2T4qNiA==",
       "requires": {
-        "fast-redact": "^1.4.2",
-        "fast-safe-stringify": "^2.0.6",
-        "flatstr": "^1.0.9",
-        "pino-std-serializers": "^2.3.0",
-        "quick-format-unescaped": "^3.0.0",
-        "sonic-boom": "^0.7.1"
+        "fast-redact": "^2.0.0",
+        "fast-safe-stringify": "^2.0.7",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^2.4.2",
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.2"
       }
     },
     "pino-pretty": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-2.5.0.tgz",
-      "integrity": "sha512-odR4SKdyubhe4aFts0/mBau2/mJLG23Ghyo86a+GZ2/Cev3CRr5nYv2+82V7v1hQL93yRSO004ASrrF7278TNQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.2.0.tgz",
+      "integrity": "sha512-CBFLgxMj/cJOANqZs+Xcjdgi1v40TJP3xMTkSN2xuOvX+03uAAHXf9SEU+1DHu/1kw44H2c31VYCImx0QewQ6w==",
       "requires": {
-        "args": "^5.0.0",
-        "chalk": "^2.3.2",
+        "@hapi/bourne": "^2.0.0",
+        "args": "^5.0.1",
+        "chalk": "^4.0.0",
         "dateformat": "^3.0.3",
-        "fast-json-parse": "^1.0.3",
-        "fast-safe-stringify": "^2.0.6",
+        "fast-safe-stringify": "^2.0.7",
         "jmespath": "^0.15.0",
+        "joycon": "^2.2.5",
         "pump": "^3.0.0",
-        "readable-stream": "^3.0.6",
-        "split2": "^3.0.0"
+        "readable-stream": "^3.6.0",
+        "split2": "^3.1.1",
+        "strip-json-comments": "^3.1.1"
       }
     },
     "pino-std-serializers": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.3.0.tgz",
-      "integrity": "sha512-klfGoOsP6sJH7ON796G4xoUSx2fkpFgKHO4YVVO2zmz31jR+etzc/QzGJILaOIiCD6HTCFgkPx+XN8nk+ruqPw=="
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz",
+      "integrity": "sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg=="
     },
     "pump": {
       "version": "3.0.0",
@@ -528,20 +549,15 @@
         "once": "^1.3.1"
       }
     },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
     "quick-format-unescaped": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.1.tgz",
-      "integrity": "sha512-Tnk4iJQ8x3V8ml3x9sLIf4tSDaVB9OJY/5gOrnxgK63CXKphhn8oYOPI4tqnXPQcZ3tCv7GFjeoYY5h6UAvuzg=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
     },
     "readable-stream": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-      "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -549,33 +565,39 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "sonic-boom": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.1.tgz",
-      "integrity": "sha512-zveqTNcDTI35ae0LgK/SwHkFeMfe6FJKyeACgPzuOe3f+9CyaoXJHTnDgekXt8PKIoMCGF/m57/9RNjjkqmt2A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.1.0.tgz",
+      "integrity": "sha512-JyOf+Xt7GBN4tAic/DD1Bitw6OMgSHAnswhPeOiLpfRoSjPNjEIi73UF3OxHzhSNn9WavxGuCZzprFCGFSNwog==",
       "requires": {
-        "flatstr": "^1.0.9"
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
       }
     },
     "split2": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.0.tgz",
-      "integrity": "sha512-ePE1otNQVMnBRyqf3INbZvZwBPGsdBDThgrOWZ6z8zXGNVQNVCSEoOO9aBMTzDN1mXoNSZJ2kHSFH7AA5SPWww==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "requires": {
         "readable-stream": "^3.0.0"
       }
     },
     "string_decoder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -583,14 +605,6 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
-      }
-    },
-    "topo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-      "requires": {
-        "hoek": "6.x.x"
       }
     },
     "util-deprecate": {
@@ -602,11 +616,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "homepage": "https://github.com/render-examples/hapi-quickstart#readme",
   "dependencies": {
-    "hapi": "^17.8.1",
-    "hapi-pino": "^5.2.0",
-    "inert": "^5.1.2"
+    "@hapi/hapi": "^20.0.0",
+    "@hapi/inert": "^6.0.2",
+    "hapi-pino": "^8.2.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const Hapi = require("hapi");
+const Hapi = require("@hapi/hapi");
 
 const server = Hapi.server({
   port: 3000,
@@ -31,7 +31,7 @@ const init = async () => {
 
   await server.register([
     {
-      plugin: require("inert"),
+      plugin: require("@hapi/inert"),
       options: {}
     },
     {


### PR DESCRIPTION
* Migrate from deprecated `hapi` and `inert` to `@hapi/hapi` and
  `@hapi/inert`.
* Bump all versions to the latest.